### PR TITLE
Fix: gradle설정 및 Entity간 연관관계 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment Variable ###
+.env*

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/plitsoft/ojt/user/domain/Pw.java
+++ b/src/main/java/com/plitsoft/ojt/user/domain/Pw.java
@@ -2,16 +2,29 @@ package com.plitsoft.ojt.user.domain;
 
 import com.plitsoft.ojt.global.domain.CommonDAO;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Pw extends CommonDAO {
 
     @Id @GeneratedValue
-    @Column(name = "user_pw_id")
+    @Column(name = "pw_save_id")
     private Long id;
 
-    @OneToOne( mappedBy = "id")
+    @OneToOne(mappedBy = "password")
     private User user;
 
+    private String salt;
+
     private String pw;
+
+    public Pw() {}
+
+    public Pw(Long id, User user, String salt, String pw) {
+        this.id = id;
+        this.user = user;
+        this.salt = salt;
+        this.pw = pw;
+    }
 }

--- a/src/main/java/com/plitsoft/ojt/user/domain/User.java
+++ b/src/main/java/com/plitsoft/ojt/user/domain/User.java
@@ -39,5 +39,6 @@ public class User extends CommonDAO {
 
     private String desc;
 
+    @Enumerated(EnumType.STRING)
     private UserRole role;
 }

--- a/src/main/java/com/plitsoft/ojt/user/domain/User.java
+++ b/src/main/java/com/plitsoft/ojt/user/domain/User.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Entity
 @Getter @Setter
 public class User extends CommonDAO {
@@ -17,13 +19,22 @@ public class User extends CommonDAO {
     private String email;
     private String userName;
 
-    @OneToOne(mappedBy = "id")
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "pw_id")
     private Pw password;
 
-    @ManyToOne()
+    @OneToMany(
+            mappedBy = "id",
+            fetch = FetchType.LAZY, cascade = CascadeType.ALL
+    )
+    private List<Pw> pw_history;
+
+    @ManyToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "part_id")
     private Part part;
 
-    @OneToOne(mappedBy = "id")
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "img_id")
     private FileData img;
 
     private String desc;

--- a/src/main/java/com/plitsoft/ojt/user/domain/UserRole.java
+++ b/src/main/java/com/plitsoft/ojt/user/domain/UserRole.java
@@ -1,4 +1,6 @@
 package com.plitsoft.ojt.user.domain;
 
 public enum UserRole {
+    ADMIN,
+    USER
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,19 @@
+# env import
+spring.config.import=optional:file:.env[.properties]
+
 spring.application.name=ojt
+
+# db settings
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=org.h2.Driver
+
+# jpa settings
+spring.jpa.hibernate.ddl-auto=validate
+# ?> db table? entity? mapping???? ??
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# logging settings
+logging.level.org.hibernate.sql=debug


### PR DESCRIPTION
# Fix: gradle설정 및 Entity간 연관관계 오류 수정
## 주요 수정사항
- Gradle 설정정보 추가 (application.properties)
  - 환경변수 적용옵션 추가
  - db 설정정보 추가
  - jpa 검사조건 및 로깅옵션 추가
- Entity 간 연관관계 오류 수정
  - `@XToMany` mappedBy 옵션설정을 통해 연관관계 주인을 명확히 수정
  -  `@XToOne` 적용 field에 `@JoinedColumn` Annotation을 추가하여 join할 필드명 명시적으로 지정
- 연관관계 간 Cascade 및 Lazy Loading 설정